### PR TITLE
fix(formula): pin archive URL with valid checksum

### DIFF
--- a/Formula/kxxx.rb
+++ b/Formula/kxxx.rb
@@ -1,9 +1,9 @@
 class Kxxx < Formula
   desc "Keychain-first secrets CLI for macOS"
   homepage "https://github.com/kxxx-dev/kxxx"
-  url "https://github.com/kxxx-dev/kxxx/archive/refs/heads/main.tar.gz"
+  url "https://github.com/kxxx-dev/kxxx/archive/c35325451f14beec2cdc83462cba44a2b30c7298.tar.gz"
   version "0.1.0"
-  sha256 :no_check
+  sha256 "e829a871effccc6181b01088c892cdcd1b636f175326166461ea2b334faef365"
   license "MIT"
 
   depends_on :macos


### PR DESCRIPTION
Fix Homebrew install failure by replacing no_check with a pinned archive URL and sha256.