### PR TITLE
docs: clarify broker audit behavior

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,14 +55,14 @@ kxxx migrate service --from nil.secrets --to kxxx.secrets --apply
 
 ## Safe Path vs Compatibility Path
 
-- Safe path: `kxxx broker github.create_issue` accepts an opaque `SecretRef`, applies a minimal repo allowlist policy, then (if allowed) resolves the secret internally and performs the provider call without returning the raw secret.
-- Safe path audit: `kxxx broker audit` exports structured JSONL events from `~/.local/state/kxxx/broker.audit.jsonl` by default, or from `KXXX_BROKER_AUDIT_LOG` / `--file` when explicitly directed.
+- Safe path: `kxxx broker github.create_issue` accepts an opaque `SecretRef`, applies a minimal repo allowlist policy, records structured broker audit events, then (if allowed) resolves the secret internally and performs the provider call without returning the raw secret.
+- Safe path audit: `kxxx broker audit` exports the structured broker event log from `~/.local/state/kxxx/broker.audit.jsonl` by default, or from `KXXX_BROKER_AUDIT_LOG` / `--file <path>` when overridden.
 - Compatibility path: `get`, `env`, and `run` remain available for existing workflows and can still materialize secret values to the caller or child process environment.
-- Compatibility audit: legacy `kxxx audit` remains a filesystem secret scanner and is not used to view broker runtime events.
+- Legacy audit path: `kxxx audit` still scans files for leaked secrets; it does not read or format the broker runtime audit log.
 
 This MVP keeps the new safe path intentionally narrow:
 
 - only `github.create_issue` is brokered
 - only an in-memory `SecretRef` backend is included
 - policy is a minimal exact-match allowlist loaded from `~/.config/kxxx/broker/github.create_issue.repos`
-- broker audit is append-only JSONL with flat machine-readable capability/event fields and no raw secret material
+- structured broker audit events are stored as JSONL and never include raw secret material

--- a/completions/_kxxx
+++ b/completions/_kxxx
@@ -57,23 +57,23 @@ _kxxx() {
       if [[ -z "$broker_op" ]]; then
         local -a broker_ops=(
           'github.create_issue:create a GitHub issue via safe path'
-          'audit:export structured broker audit JSONL'
+          'audit:export structured broker audit events'
         )
         _describe 'broker operation' broker_ops
         return
       fi
       case "$broker_op" in
+        audit)
+          _arguments \
+            '--file[audit log file path]:path:_files' \
+            '(-h --help)'{-h,--help}'[show help]'
+          ;;
         github.create_issue)
           _arguments \
             '--ref[opaque secret reference]:secret-ref:' \
             '--repo[target repository]:repository:' \
             '--title[issue title]:title:' \
             '--body[issue body]:body:' \
-            '(-h --help)'{-h,--help}'[show help]'
-          ;;
-        audit)
-          _arguments \
-            '--file[structured broker audit file]:path:_files' \
             '(-h --help)'{-h,--help}'[show help]'
           ;;
       esac

--- a/docs/SAFE_PATH_MVP.md
+++ b/docs/SAFE_PATH_MVP.md
@@ -8,14 +8,17 @@ This slice adds the first brokered safe path to `kxxx` without changing the lega
 - in-memory backend: test/local-spike storage for `SecretRef -> secret material`
 - one brokered operation: `github.create_issue`
 - one minimal policy gate: provider must be `github`, operation must be `create_issue`, and repo must be allowlisted
-- one minimal audit trail: structured JSONL broker events with no raw secret material
+- one minimal audit trail: sanitized structured broker events with no raw secret material
 
 ## Runtime Boundary
 
 The caller provides only a `SecretRef`.
 `kxxx` checks policy at the broker boundary, resolves the raw secret internally, and performs the provider call behind that boundary.
-The broker result and audit event never include the raw secret.
-Structured audit events are exported with `kxxx broker audit`; the legacy `kxxx audit` command remains the compatibility-path filesystem scanner.
+The broker result and structured audit events never include the raw secret.
+
+`kxxx broker audit` exports the broker runtime JSONL log from `~/.local/state/kxxx/broker.audit.jsonl` by default.
+If `KXXX_BROKER_AUDIT_LOG` or `--file <path>` is provided, that path is used instead.
+This is separate from the legacy `kxxx audit` command, which remains a filesystem secret scanner.
 
 ## Intentionally Out of Scope
 
@@ -30,4 +33,4 @@ Structured audit events are exported with `kxxx broker audit`; the legacy `kxxx 
 - the in-memory backend is process-local, so this MVP is primarily proven through tests and internal APIs
 - the safe path is limited to GitHub issue creation
 - policy configuration is intentionally minimal and loaded from `~/.config/kxxx/broker/github.create_issue.repos`
-- broker audit defaults to `~/.local/state/kxxx/broker.audit.jsonl` and can be overridden with `KXXX_BROKER_AUDIT_LOG` or `kxxx broker audit --file`
+- structured audit viewing/export is intentionally narrow and only exposes raw JSONL broker events


### PR DESCRIPTION
## Summary
- clarify README wording around broker audit events and the legacy audit boundary
- improve `kxxx broker audit` completion text and `--file` help wording
- expand the SAFE_PATH MVP brief with explicit runtime audit log details

## Testing
- git diff --check
- zsh -n completions/_kxxx
