### PR TITLE
ci: add GitHub Actions test workflow

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,46 @@
+name: test
+
+on:
+  pull_request:
+    branches:
+      - main
+  push:
+    branches:
+      - main
+
+permissions:
+  contents: read
+
+concurrency:
+  group: test-${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  test:
+    name: test
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v6
+
+      - name: Install test dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y bats zsh
+
+      - name: Print tool versions
+        run: |
+          bash --version
+          bats --version
+          zsh --version
+
+      - name: Validate bash scripts
+        run: bash -n bin/kxxx lib/kxxx/*.sh test/test_helper.bash
+
+      - name: Validate zsh completion
+        run: zsh -n completions/_kxxx
+
+      - name: Run broker tests
+        run: timeout 5m bats test/broker.bats


### PR DESCRIPTION
## Summary
- add a new `test` GitHub Actions workflow for pushes to `main` and pull requests targeting `main`
- run the repo's current bash syntax, zsh syntax, and broker bats checks in a single `ubuntu-latest` job
- bound the CI run with workflow concurrency plus per-job and per-test timeouts

## Testing
- `bash -n bin/kxxx lib/kxxx/*.sh test/test_helper.bash`
- `zsh -n completions/_kxxx`
- `git diff --check`
- `timeout 20s bats test/broker.bats` (times out in this local Codex environment before test execution; relying on GitHub Actions for the authoritative run)

## Notes
- workflow and job are both named `test` so this can be promoted to a required check later without renaming
- this change intentionally does not add `shellcheck` or branch protection updates
