### PR TITLE
feat(broker): support keychain refs in safe path

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 Safe path is preferred for new integrations, and new integrations should prefer brokered execution when possible. In the safe path, `kxxx` resolves secret material internally and returns only the brokered result. Compatibility-path commands remain available for existing workflows, but they can materialize raw secrets to the caller or child process environment and are therefore less safe.
 
-The current narrow MVP is `kxxx broker github.create_issue`. Today it is primarily proven through tests and internal APIs, and [docs/SAFE_PATH_MVP.md](docs/SAFE_PATH_MVP.md) defines the slice boundary and current limitations.
+The current narrow MVP is `kxxx broker github.create_issue`. Callers can look up a broker-usable `secret_ref` with `kxxx ref <descriptor> --service <name>` and pass that ref plus `--service` to the broker, and [docs/SAFE_PATH_MVP.md](docs/SAFE_PATH_MVP.md) defines the slice boundary and current limitations.
 
 ## Safe Path vs Compatibility Path
 
@@ -16,7 +16,7 @@ The current narrow MVP is `kxxx broker github.create_issue`. Today it is primari
 This MVP keeps the new safe path intentionally narrow:
 
 - only `github.create_issue` is brokered
-- only an in-memory `SecretRef` backend is included
+- broker-visible refs are limited to `kxxx`-managed `secretref:v1:keychain:*` identities plus process-local `secretref:v1:memory:*` refs for tests and internal APIs
 - policy is a minimal exact-match allowlist loaded from `~/.config/kxxx/broker/github.create_issue.repos`
 - structured broker audit events are stored as JSONL and never include raw secret material
 
@@ -31,11 +31,12 @@ brew install kxxx
 
 ```bash
 kxxx set <account> [--value <value>|--stdin] [--json] [--service <name>]
+kxxx ref <account> [--service <name>] [--json]
 kxxx get <account> [--service <name>] [--fallback-service <name>]
 kxxx list [--service <name>] [--json]
 kxxx env [--repo <auto|name>] [--shell <zsh|bash|dotenv|json>] [--service <name>] [--strict]
 kxxx run [--repo <auto|name>] [--service <name>] -- <command...>
-kxxx broker github.create_issue --ref <secret-ref> --repo <owner/repo> --title <title> [--body <body>]
+kxxx broker github.create_issue [--service <name>] --ref <secret-ref> --repo <owner/repo> --title <title> [--body <body>]
 kxxx broker audit [--file <path>]
 kxxx migrate import [--dry-run|--apply] [--service <name>] [--keys-root <path>]
 kxxx migrate service [--from nil.secrets] [--to kxxx.secrets] [--dry-run|--apply]
@@ -57,10 +58,11 @@ kxxx set env/OPENAI_API_KEY --value secret-value --json
 ## Typical usage
 
 ```bash
-# preferred safe path today: start with the brokered MVP entrypoints
-kxxx broker --help
+# preferred safe path today: look up an opaque ref and pass only that ref to the broker
+ref="$(kxxx ref env/GITHUB_TOKEN --service kxxx.secrets)"
+kxxx broker github.create_issue --service kxxx.secrets --ref "$ref" --repo octo/repo --title "hello"
 
-# current MVP note: the in-memory SecretRef backend is primarily proven through tests and internal APIs
+# current MVP note: process-local memory refs are still mainly for tests and internal APIs
 # see docs/SAFE_PATH_MVP.md for the current slice boundary and limitations
 
 # set global env secret

--- a/bin/kxxx
+++ b/bin/kxxx
@@ -35,11 +35,12 @@ kxxx_usage() {
   cat <<'USAGE'
 Usage:
   kxxx set <account> [--value <value>|--stdin] [--json] [--service <name>]
+  kxxx ref <account> [--service <name>] [--json]
   kxxx get <account> [--service <name>] [--fallback-service <name>]
   kxxx list [--service <name>] [--json]
   kxxx env [--repo <auto|name>] [--shell <zsh|bash|dotenv|json>] [--service <name>] [--strict]
   kxxx run [--repo <auto|name>] [--service <name>] -- <command...>
-  kxxx broker github.create_issue --ref <secret-ref> --repo <owner/repo> --title <title> [--body <body>]
+  kxxx broker github.create_issue [--service <name>] --ref <secret-ref> --repo <owner/repo> --title <title> [--body <body>]
   kxxx broker audit [--file <path>]
   kxxx migrate import [--dry-run|--apply] [--service <name>] [--keys-root <path>]
   kxxx migrate service [--from <name>] [--to <name>] [--dry-run|--apply]
@@ -116,6 +117,53 @@ USAGE
       "$(kxxx_json_escape "$service")" \
       "$(kxxx_json_escape "$account")"
   fi
+}
+
+cmd_ref() {
+  local service="${KXXX_DEFAULT_SERVICE}" output="text" account="" resolved_ref=""
+  while (($# > 0)); do
+    case "$1" in
+      --service)
+        shift
+        [[ $# -gt 0 ]] || kxxx_die "missing value for --service"
+        service="$1"
+        ;;
+      --service=*)
+        service="${1#*=}"
+        [[ -n "$service" ]] || kxxx_die "missing value for --service"
+        ;;
+      --json)
+        output="json"
+        ;;
+      -h|--help)
+        cat <<'USAGE'
+Usage: kxxx ref <account> [--service <name>] [--json]
+USAGE
+        return 0 ;;
+      --*)
+        kxxx_die "unknown option: $1" ;;
+      *)
+        if [[ -z "$account" ]]; then
+          account="$1"
+        else
+          kxxx_die "unexpected argument: $1"
+        fi ;;
+    esac
+    shift || true
+  done
+
+  [[ -n "$account" ]] || kxxx_die "account is required"
+  kxxx_identity_get_descriptor_ref "$service" "$account" resolved_ref || return 1
+
+  if [[ "$output" == "json" ]]; then
+    printf '{"status":"ok","service":"%s","account":"%s","secret_ref":"%s"}\n' \
+      "$(kxxx_json_escape "$service")" \
+      "$(kxxx_json_escape "$account")" \
+      "$(kxxx_json_escape "$resolved_ref")"
+    return 0
+  fi
+
+  printf '%s\n' "$resolved_ref"
 }
 
 cmd_get() {
@@ -322,6 +370,9 @@ main() {
   case "$cmd" in
     set)
       cmd_set "$@"
+      ;;
+    ref)
+      cmd_ref "$@"
       ;;
     get)
       cmd_get "$@"

--- a/completions/_kxxx
+++ b/completions/_kxxx
@@ -4,6 +4,7 @@ _kxxx() {
   local -a commands
   commands=(
     'set:set secret value'
+    'ref:get opaque secret reference'
     'get:get secret value'
     'list:list accounts for service'
     'env:print env exports'
@@ -28,6 +29,12 @@ _kxxx() {
         '--service[service name]:service:' \
         '--value[value to set]:value:' \
         '--stdin[read value from stdin]' \
+        '--json[emit JSON output]' \
+        '(-h --help)'{-h,--help}'[show help]'
+      ;;
+    ref)
+      _arguments \
+        '--service[service name]:service:' \
         '--json[emit JSON output]' \
         '(-h --help)'{-h,--help}'[show help]'
       ;;
@@ -70,6 +77,7 @@ _kxxx() {
           ;;
         github.create_issue)
           _arguments \
+            '--service[service name for keychain-backed refs]:service:' \
             '--ref[opaque secret reference]:secret-ref:' \
             '--repo[target repository]:repository:' \
             '--title[issue title]:title:' \

--- a/docs/SAFE_PATH_MVP.md
+++ b/docs/SAFE_PATH_MVP.md
@@ -6,8 +6,8 @@ This slice adds the first brokered safe path to `kxxx` without changing the lega
 
 - provider: GitHub
 - operation: `github.create_issue`
-- `SecretRef`: opaque identity in the form `secretref:v1:memory:<id>`
-- in-memory backend: test/local-spike storage for `SecretRef -> secret material`
+- `SecretRef`: opaque identity in the form `secretref:v1:<backend>:<id>`
+- supported refs: `kxxx`-managed `secretref:v1:keychain:<id>` for CLI-visible flows and `secretref:v1:memory:<id>` for tests/internal spikes
 - minimum policy gate: provider must be `github`, operation must be `create_issue`, and repo must be allowlisted
 - minimal audit trail: sanitized structured broker events with no raw secret material
 
@@ -25,9 +25,10 @@ This is separate from the legacy `kxxx audit` command, which remains a filesyste
 
 Supported entrypoint:
 
-`kxxx broker github.create_issue --ref <secret-ref> --repo <owner/repo> --title <title> [--body <body>]`
+`kxxx broker github.create_issue [--service <name>] --ref <secret-ref> --repo <owner/repo> --title <title> [--body <body>]`
 
-- `--ref` is required and must be a `secretref:v1:memory:<id>` for this MVP slice
+- `--service` is required for `secretref:v1:keychain:<id>` refs and optional for `secretref:v1:memory:<id>` refs
+- `--ref` is required and may be a `secretref:v1:keychain:<id>` from `kxxx ref <descriptor> --service <name>` or a `secretref:v1:memory:<id>` for tests and internal spikes
 - `--repo` is required and identifies the target repository in `owner/repo` form
 - `--title` is required
 - `--body` is optional
@@ -40,6 +41,7 @@ Supported entrypoint:
 - failure returns a non-zero exit code, no stdout payload, and stderr-only errors such as:
   - `kxxx: broker audit log write failed`
   - `kxxx: broker policy denied github.create_issue for repo=<owner/repo>`
+  - `kxxx: --service is required for keychain secret refs`
   - `kxxx: secret ref could not be resolved`
   - `kxxx: broker provider request failed`
 - post-provider audit append failure is a warning-only stderr event, `kxxx: broker audit log write failed after provider success`, and does not turn a successful provider result into a failed command
@@ -60,13 +62,14 @@ Proof-oriented coverage lives in `test/broker.bats` and should continue to verif
 
 - multiple providers
 - policy DSLs
-- persistent safe-path backends
+- generalized persistent safe-path backends beyond the existing managed keychain path
 - cross-platform keychain abstractions
 - refactoring existing compatibility commands
 
 ## Current Limitations
 
-- the in-memory backend is process-local, so this MVP is primarily proven through tests and internal APIs
+- keychain-backed refs are broker-usable when they exist in the local secret index created by `kxxx set` or `migrate import --apply`, and the caller supplies the matching `--service`
+- the in-memory backend remains process-local for tests and internal APIs
 - the safe path is limited to GitHub issue creation
 - policy configuration is intentionally minimal and loaded from `~/.config/kxxx/broker/github.create_issue.repos`
 - structured audit viewing/export is intentionally narrow and only exposes raw JSONL broker events

--- a/lib/kxxx/broker.sh
+++ b/lib/kxxx/broker.sh
@@ -1,6 +1,11 @@
 #!/usr/bin/env bash
 
 kxxx_broker_home_dir() {
+  if [[ -n "${KXXX_BROKER_HOME:-}" ]]; then
+    printf '%s\n' "$KXXX_BROKER_HOME"
+    return 0
+  fi
+
   local user_name=""
   user_name="$(id -un)"
 
@@ -270,7 +275,7 @@ kxxx_github_http_create_issue() {
 }
 
 kxxx_broker_execute_github_create_issue() {
-  local ref="$1" repo="$2" title="$3" body="$4"
+  local service="$1" ref="$2" repo="$3" title="$4" body="$5"
   local token="" provider="github" operation="create_issue"
   local response="" http_status="" issue_number="" issue_url=""
   local sink="" request_id="" backend="" audit_ref=""
@@ -322,7 +327,29 @@ kxxx_broker_execute_github_create_issue() {
     return 1
   fi
 
-  if ! kxxx_secret_resolve "$ref" token; then
+  if [[ "$backend" == "keychain" ]]; then
+    if [[ -z "$service" ]]; then
+      extra_fields="$(printf '"backend":"%s","result":"unresolved","reason":"service_required_for_keychain_ref"' \
+        "$(kxxx_json_escape "$backend")")"
+      if ! kxxx_broker_emit_event "$sink" "$request_id" "secret_resolution" "$provider" "$operation" "$repo" "$audit_ref" "$extra_fields"; then
+        echo "kxxx: broker audit log write failed" >&2
+        return 1
+      fi
+      echo "kxxx: --service is required for keychain secret refs" >&2
+      return 1
+    fi
+
+    if ! token="$(kxxx_keychain_get_ref "$service" "$ref")"; then
+      extra_fields="$(printf '"backend":"%s","result":"unresolved","reason":"secret_ref_unresolved"' \
+        "$(kxxx_json_escape "$backend")")"
+      if ! kxxx_broker_emit_event "$sink" "$request_id" "secret_resolution" "$provider" "$operation" "$repo" "$audit_ref" "$extra_fields"; then
+        echo "kxxx: broker audit log write failed" >&2
+        return 1
+      fi
+      echo "kxxx: secret ref could not be resolved" >&2
+      return 1
+    fi
+  elif ! kxxx_secret_resolve "$ref" token; then
     extra_fields="$(printf '"backend":"%s","result":"unresolved","reason":"secret_ref_unresolved"' \
       "$(kxxx_json_escape "$backend")")"
     if ! kxxx_broker_emit_event "$sink" "$request_id" "secret_resolution" "$provider" "$operation" "$repo" "$audit_ref" "$extra_fields"; then
@@ -416,7 +443,7 @@ kxxx_broker_audit_main() {
 kxxx_broker_usage() {
   cat <<'USAGE'
 Usage:
-  kxxx broker github.create_issue --ref <secret-ref> --repo <owner/repo> --title <title> [--body <body>]
+  kxxx broker github.create_issue [--service <name>] --ref <secret-ref> --repo <owner/repo> --title <title> [--body <body>]
   kxxx broker audit [--file <path>]
 
 Notes:
@@ -427,7 +454,7 @@ USAGE
 }
 
 kxxx_broker_main() {
-  local operation="${1:-}" ref="" repo="" title="" body=""
+  local operation="${1:-}" service="" ref="" repo="" title="" body=""
   if [[ $# -eq 0 || "$operation" == "-h" || "$operation" == "--help" || "$operation" == "help" ]]; then
     kxxx_broker_usage
     return 0
@@ -450,6 +477,14 @@ kxxx_broker_main() {
         ;;
       --ref=*)
         ref="${1#*=}"
+        ;;
+      --service)
+        shift
+        [[ $# -gt 0 ]] || kxxx_die "missing value for --service"
+        service="$1"
+        ;;
+      --service=*)
+        service="${1#*=}"
         ;;
       --repo)
         shift
@@ -495,7 +530,7 @@ kxxx_broker_main() {
 
   case "$operation" in
     github.create_issue)
-      kxxx_broker_execute_github_create_issue "$ref" "$repo" "$title" "$body"
+      kxxx_broker_execute_github_create_issue "$service" "$ref" "$repo" "$title" "$body"
       ;;
     *)
       kxxx_die "unsupported broker operation: $operation"

--- a/lib/kxxx/identity.sh
+++ b/lib/kxxx/identity.sh
@@ -168,6 +168,18 @@ kxxx_identity_find_record_by_ref() {
   kxxx_identity_find_record "$1" "ref" "$2" "$3" "$4" "$5" "$6" "$7"
 }
 
+kxxx_identity_get_descriptor_ref() {
+  local service="$1" descriptor="$2"
+  local -n ref_ref="$3"
+  local found_ref="" existing_descriptor="" binding_scope="" binding_repo="" binding_name=""
+
+  if ! kxxx_identity_find_record_by_descriptor "$service" "$descriptor" found_ref existing_descriptor binding_scope binding_repo binding_name; then
+    return 1
+  fi
+
+  ref_ref="$found_ref"
+}
+
 kxxx_identity_upsert_record() {
   local service="$1" ref="$2" descriptor="$3" binding_scope="$4" binding_repo="$5" binding_name="$6"
   local index_file="" index_dir="" tmp_file=""

--- a/test/broker.bats
+++ b/test/broker.bats
@@ -138,6 +138,81 @@ teardown() {
   broker_test_assert_no_leaks "$combined_output" "$secret"
 }
 
+@test "github.create_issue resolves keychain refs when service is provided" {
+  local secret="github_pat_keychain_secret_value_123456789"
+  local ref="secretref:v1:keychain:broker-ref"
+  local audit_path="$BATS_TEST_TMPDIR/keychain-success.jsonl"
+  local policy_file="$KXXX_TEST_HOME/.config/kxxx/broker/github.create_issue.repos"
+  local combined_output=""
+
+  export KXXX_BROKER_AUDIT_LOG="$audit_path"
+  mkdir -p "$(dirname "$policy_file")"
+  printf '%s\n' "octo/repo" > "$policy_file"
+
+  kxxx_keychain_get_ref() {
+    local service="$1" ref_arg="$2"
+    [[ "$service" == "test.secrets" ]]
+    [[ "$ref_arg" == "$ref" ]]
+    printf '%s\n' "$secret"
+  }
+
+  kxxx_github_http_create_issue() {
+    local token="$1"
+    local -n response_ref="$5"
+    local -n status_ref="$6"
+
+    printf '%s' "$token" > "$KXXX_TEST_PROVIDER_MARKER"
+    response_ref='{"number":52,"html_url":"https://github.com/octo/repo/issues/52"}'
+    status_ref="201"
+    return 0
+  }
+
+  run --separate-stderr kxxx_broker_main github.create_issue --service test.secrets --ref "$ref" --repo octo/repo --title "hello"
+
+  [ "$status" -eq 0 ]
+  [[ "$output" == *'"status":"ok"'* ]]
+  [[ "$output" == *'"issue_number":52'* ]]
+  [[ "$output" == *'"issue_url":"https://github.com/octo/repo/issues/52"'* ]]
+  [[ -z "$stderr" ]]
+  [[ "$(cat "$KXXX_TEST_PROVIDER_MARKER")" == "$secret" ]]
+
+  broker_test_load_audit_lines "$audit_path"
+  [ "${#BROKER_TEST_AUDIT_LINES[@]}" -eq 5 ]
+  [[ "$(broker_test_json_string "${BROKER_TEST_AUDIT_LINES[2]}" "backend")" == "keychain" ]]
+  [[ "$(broker_test_json_string "${BROKER_TEST_AUDIT_LINES[3]}" "backend")" == "keychain" ]]
+  [[ "$(broker_test_json_string "${BROKER_TEST_AUDIT_LINES[3]}" "result")" == "resolved" ]]
+
+  combined_output="$(printf '%s\n%s\n%s' "$output" "$stderr" "$(cat "$audit_path")")"
+  broker_test_assert_no_leaks "$combined_output" "$secret"
+}
+
+@test "keychain secret refs require --service" {
+  local ref="secretref:v1:keychain:missing-service"
+  local audit_path="$BATS_TEST_TMPDIR/keychain-missing-service.jsonl"
+  local policy_file="$KXXX_TEST_HOME/.config/kxxx/broker/github.create_issue.repos"
+
+  export KXXX_BROKER_AUDIT_LOG="$audit_path"
+  mkdir -p "$(dirname "$policy_file")"
+  printf '%s\n' "octo/repo" > "$policy_file"
+
+  kxxx_keychain_get_ref() {
+    printf 'called' > "$KXXX_TEST_PROVIDER_MARKER"
+    return 99
+  }
+
+  run --separate-stderr kxxx_broker_main github.create_issue --ref "$ref" --repo octo/repo --title "hello"
+
+  [ "$status" -ne 0 ]
+  [[ -z "$output" ]]
+  [[ "$stderr" == *'--service is required for keychain secret refs'* ]]
+  [[ ! -s "$KXXX_TEST_PROVIDER_MARKER" ]]
+
+  broker_test_load_audit_lines "$audit_path"
+  [ "${#BROKER_TEST_AUDIT_LINES[@]}" -eq 4 ]
+  [[ "$(broker_test_json_string "${BROKER_TEST_AUDIT_LINES[2]}" "backend")" == "keychain" ]]
+  [[ "$(broker_test_json_string "${BROKER_TEST_AUDIT_LINES[3]}" "reason")" == "service_required_for_keychain_ref" ]]
+}
+
 @test "policy deny blocks secret resolution and provider execution" {
   local secret="github_pat_secret_for_deny_123456789"
   local ref=""

--- a/test/fixtures/curl-stub.sh
+++ b/test/fixtures/curl-stub.sh
@@ -1,0 +1,29 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+output_file=""
+config_file=""
+
+while (($# > 0)); do
+  case "$1" in
+    --output)
+      shift
+      output_file="$1"
+      ;;
+    --config)
+      shift
+      config_file="$1"
+      ;;
+  esac
+  shift || true
+done
+
+if [[ -n "${KXXX_TEST_PROVIDER_MARKER:-}" && -n "$config_file" ]]; then
+  sed -n 's/^header = \"Authorization: Bearer \(.*\)\"$/\1/p' "$config_file" > "$KXXX_TEST_PROVIDER_MARKER"
+fi
+
+if [[ -n "$output_file" ]]; then
+  printf '%s' '{"number":42,"html_url":"https://github.com/octo/repo/issues/42"}' > "$output_file"
+fi
+
+printf '201'

--- a/test/identity.bats
+++ b/test/identity.bats
@@ -27,7 +27,12 @@ single_ref_account() {
 }
 
 run_kxxx() {
-  run env HOME="$KXXX_TEST_HOME" PATH="$KXXX_TEST_BIN:$KXXX_ORIG_PATH" "$KXXX_BIN" "$@"
+  run env HOME="$KXXX_TEST_HOME" KXXX_BROKER_HOME="$KXXX_TEST_HOME" PATH="$KXXX_TEST_BIN:$KXXX_ORIG_PATH" "$KXXX_BIN" "$@"
+}
+
+install_curl_stub() {
+  cp "$BATS_TEST_DIRNAME/fixtures/curl-stub.sh" "$KXXX_TEST_BIN/curl"
+  chmod +x "$KXXX_TEST_BIN/curl"
 }
 
 test_set_stores_new_values_under_an_opaque_ref_and_records_the_descriptor_mapping() { #@test
@@ -163,4 +168,47 @@ test_migrate_import_apply_writes_imported_secrets_through_opaque_refs_instead_of
   run_kxxx get env/GITHUB_MCP_TOKEN --service test.secrets
   [ "$status" -eq 0 ]
   [ "$output" = "from-dotfile" ]
+}
+
+test_ref_returns_the_managed_secret_ref() { #@test
+  run_kxxx set env/GITHUB_TOKEN --service test.secrets --value broker-secret
+  [ "$status" -eq 0 ]
+  [ -z "$output" ]
+
+  run_kxxx ref env/GITHUB_TOKEN --service test.secrets --json
+  [ "$status" -eq 0 ]
+  [[ "$output" == *'"status":"ok"'* ]]
+  [[ "$output" == *'"service":"test.secrets"'* ]]
+  [[ "$output" == *'"account":"env/GITHUB_TOKEN"'* ]]
+  [[ "$output" == *'"secret_ref":"secretref:v1:keychain:'* ]]
+}
+
+test_broker_resolves_keychain_secret_refs_from_ref_without_exposing_the_secret() { #@test
+  local policy_file="$KXXX_TEST_HOME/.config/kxxx/broker/github.create_issue.repos"
+  local provider_marker="$BATS_TEST_TMPDIR/provider-token"
+  local secret_ref=""
+
+  install_curl_stub
+  export KXXX_TEST_PROVIDER_MARKER="$provider_marker"
+  mkdir -p "$(dirname "$policy_file")"
+  printf '%s\n' "octo/repo" > "$policy_file"
+
+  run_kxxx set env/GITHUB_TOKEN --service test.secrets --value broker-secret
+  [ "$status" -eq 0 ]
+
+  run_kxxx ref env/GITHUB_TOKEN --service test.secrets
+  [ "$status" -eq 0 ]
+  secret_ref="$output"
+  [[ "$secret_ref" == secretref:v1:keychain:* ]]
+
+  run_kxxx broker github.create_issue --service test.secrets --ref "$secret_ref" --repo octo/repo --title "hello" --body "body"
+  [ "$status" -eq 0 ]
+  [[ "$output" == *'"status":"ok"'* ]]
+  [[ "$output" == *'"provider":"github"'* ]]
+  [[ "$output" == *'"operation":"create_issue"'* ]]
+  [[ "$output" == *'"repo":"octo/repo"'* ]]
+  [[ "$output" == *'"issue_number":42'* ]]
+  [[ "$output" == *'"issue_url":"https://github.com/octo/repo/issues/42"'* ]]
+  [[ "$output" != *'broker-secret'* ]]
+  [[ "$(cat "$provider_marker")" == "broker-secret" ]]
 }


### PR DESCRIPTION
## Summary
- add `kxxx ref` as a metadata-only lookup for managed opaque secret refs
- require broker `--service` for keychain-backed refs so `kxxx broker github.create_issue` can resolve a user-visible safe-path ref without exposing raw secrets
- update README, completions, and the MVP brief to document the new caller flow and add Bats coverage for keychain-backed broker execution

## Testing
- `bash -n bin/kxxx lib/kxxx/*.sh test/fixtures/*.sh test/test_helper.bash`
- `zsh -n completions/_kxxx`
- `git diff --check`
- `timeout 30s bats test/identity.bats`
- `timeout 30s bats test/broker.bats`

Closes #10
