### PR TITLE
docs: define agent-safe secret runtime threat model

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 Safe path is preferred for new integrations, and new integrations should prefer brokered execution when possible. In the safe path, `kxxx` resolves secret material internally and returns only the brokered result. Compatibility-path commands remain available for existing workflows, but they can materialize raw secrets to the caller or child process environment and are therefore less safe.
 
-The current narrow MVP is `kxxx broker github.create_issue`. Callers can look up a broker-usable `secret_ref` with `kxxx ref <descriptor> --service <name>` and pass that ref plus `--service` to the broker, and [docs/SAFE_PATH_MVP.md](docs/SAFE_PATH_MVP.md) defines the slice boundary and current limitations.
+The canonical threat model and v1 security invariants live in [docs/adr/0001-agent-safe-secret-runtime.md](docs/adr/0001-agent-safe-secret-runtime.md). In short: the safe path keeps raw secret values behind the broker boundary, compatibility-path commands remain explicit legacy mode, secret identity is distinct from env bindings, and current v1 audit intentionally keeps sanitized metadata such as opaque refs, backend names, target resources, and process context. The current narrow MVP is `kxxx broker github.create_issue`, and [docs/SAFE_PATH_MVP.md](docs/SAFE_PATH_MVP.md) defines only that slice boundary and its current limitations.
 
 ## Safe Path vs Compatibility Path
 
@@ -19,6 +19,15 @@ This MVP keeps the new safe path intentionally narrow:
 - broker-visible refs are limited to `kxxx`-managed `secretref:v1:keychain:*` identities plus process-local `secretref:v1:memory:*` refs for tests and internal APIs
 - policy is a minimal exact-match allowlist loaded from `~/.config/kxxx/broker/github.create_issue.repos`
 - structured broker audit events are stored as JSONL and never include raw secret material
+
+## Threat Model Summary
+
+- The preferred safe path never requires the caller or an LLM/agent to see the raw secret value; the caller supplies only a `SecretRef` plus operation arguments.
+- Compatibility-path commands remain explicit and secondary. `get`, `env`, and `run` can still materialize raw secrets for existing workflows.
+- When a brokered operation has policy, policy is evaluated before secret resolution or provider execution.
+- Raw secret values must not be emitted to stdout, stderr, or structured broker audit events.
+- The current v1 audit trail may still retain opaque refs, backend identifiers, target resources, and process metadata. Further metadata minimization is deferred until after the MVP.
+- Interactive desktop keyrings and headless/CI execution are different trust environments and should not be treated as interchangeable backend assumptions. The current implementation does not claim broader headless-safe backend support.
 
 ## Install (Homebrew tap)
 

--- a/bin/kxxx
+++ b/bin/kxxx
@@ -46,6 +46,11 @@ Usage:
   kxxx migrate service [--from <name>] [--to <name>] [--dry-run|--apply]
   kxxx audit [--summary|--list] [--strict] [paths...]
 
+Modes:
+  Safe path: `kxxx broker ...` is the preferred path for new integrations and keeps raw secret values behind the broker boundary.
+  Compatibility path: `kxxx get`, `kxxx env`, and `kxxx run` can materialize raw secrets for existing workflows.
+  Threat model and invariants: https://github.com/kxxx-dev/kxxx/blob/main/docs/adr/0001-agent-safe-secret-runtime.md
+
 Defaults:
   service: kxxx.secrets
   repo: auto

--- a/docs/SAFE_PATH_MVP.md
+++ b/docs/SAFE_PATH_MVP.md
@@ -2,6 +2,8 @@
 
 This slice adds the first brokered safe path to `kxxx` without changing the legacy compatibility commands.
 
+The canonical threat model and v1 security invariants live in [ADR 0001: Agent-safe secret runtime](adr/0001-agent-safe-secret-runtime.md). This brief is intentionally narrower: it describes the current MVP boundary and should not be treated as the source of truth for broader security policy or long-term non-goals.
+
 ## What It Adds
 
 - provider: GitHub
@@ -16,6 +18,9 @@ This slice adds the first brokered safe path to `kxxx` without changing the lega
 The caller provides only a `SecretRef` plus the brokered operation arguments.
 `kxxx` checks policy at the broker boundary, resolves the raw secret internally, and performs the provider call behind that boundary.
 The broker result and structured audit events never include the raw secret.
+
+This MVP implements the ADR invariants that the safe path keeps raw secret material behind the broker boundary, treats compatibility-path commands as explicit exceptions, and evaluates policy before secret resolution when policy exists.
+Compatibility-path commands still exist, but they are not part of this safe-path boundary.
 
 `kxxx broker audit` exports the broker runtime JSONL log from `~/.local/state/kxxx/broker.audit.jsonl` by default.
 If `KXXX_BROKER_AUDIT_LOG` or `--file <path>` is provided, that path is used instead.
@@ -73,3 +78,4 @@ Proof-oriented coverage lives in `test/broker.bats` and should continue to verif
 - the safe path is limited to GitHub issue creation
 - policy configuration is intentionally minimal and loaded from `~/.config/kxxx/broker/github.create_issue.repos`
 - structured audit viewing/export is intentionally narrow and only exposes raw JSONL broker events
+- desktop keychain behavior should not be read as a guarantee that the same backend assumptions are safe in headless or CI contexts

--- a/docs/adr/0001-agent-safe-secret-runtime.md
+++ b/docs/adr/0001-agent-safe-secret-runtime.md
@@ -1,0 +1,78 @@
+# ADR 0001: Agent-safe secret runtime
+
+- Status: Accepted
+- Date: 2026-03-07
+
+## Context
+
+`kxxx` currently sits at the overlap of three related product shapes:
+
+1. a local developer secrets CLI
+2. an agent-safe runtime and broker
+3. a future identity-aware secret infrastructure
+
+Those shapes share mechanics, but they do not share trust boundaries. Without a canonical threat model, follow-up work can accidentally optimize for storage backend convenience and slide back toward raw env injection as the default behavior. This ADR defines the security model that follow-up issues must inherit.
+
+## Decision
+
+`kxxx` treats agent-safe execution as the primary direction and raw env injection as a compatibility path. The safe path is broker-oriented: the caller provides an opaque `SecretRef` plus operation arguments, `kxxx` evaluates policy at the broker boundary, resolves the secret internally, and returns only brokered result metadata.
+
+Compatibility-path commands remain available for existing workflows, but they are explicit exceptions to the preferred model because they can materialize raw secrets in the caller or child-process environment.
+
+## Actors And Trust Boundaries
+
+| Actor | Role | Trust boundary |
+| --- | --- | --- |
+| User | Human operator configuring secrets, services, and policy | Trusted to choose intent, but configuration mistakes are still part of the threat model. |
+| Calling process / child process | Local shell, app, or tool invocation | Outside the safe boundary unless using a brokered path. Compatibility commands may expose raw secrets here. |
+| LLM / agent | Tool-using model, automation, or planner | Must be treated as untrusted with raw secret material. The safe path should expose only opaque refs and minimal result metadata. |
+| Broker / tool wrapper (`kxxx broker`) | Policy and secret-resolution boundary | Trusted to evaluate policy, resolve secrets internally, redact outputs, and enforce safe-path behavior. |
+| Storage backend | Secret persistence layer | Trusted to store and return secret bytes, but backend metadata and backend-specific quirks are not assumed secret or portable. |
+| OS keyring service | Platform keychain or secret service | Trusted only within platform constraints such as login-session presence or interactive unlock. |
+| Headless / CI runner | Non-interactive execution environment | Distinct trust environment from desktop keyring usage. It must not inherit assumptions about prompts, login sessions, or user presence. |
+| Provider API | Remote system such as GitHub | Receives the raw secret only inside the broker boundary when policy allows the operation. Provider responses are untrusted input. |
+
+## Primary Attack And Failure Modes
+
+- Prompt or tool-output injection causing unintended tool use.
+  `kxxx` must assume the LLM or agent can be manipulated. Safe-path operations therefore require explicit broker commands and policy checks at the operation boundary.
+- Secret disclosure through stdout, stderr, logs, traces, or test artifacts.
+  Raw secret values are never valid safe-path output and must not be copied into structured audit events.
+- Metadata leakage through backend lookup fields or audit records.
+  `kxxx` uses opaque `SecretRef` identifiers instead of env-style names as the primary secret identity. Limited metadata exposure still exists in v1 audit records and is treated as an explicit tradeoff, not an accident.
+- Over-privileged tool access.
+  When policy exists, deny-by-default applies before secret resolution or provider execution. The current MVP enforces this with an exact repo allowlist.
+- Cross-context mixups across repo, agent, or session boundaries.
+  Secret identity stays separate from descriptors and env bindings so future policy and audit work can scope access by explicit context rather than implicit env names.
+- Backend-specific assumptions leaking into the architecture.
+  Interactive keychain behavior and headless execution are not interchangeable. Backend/provider work must document those differences instead of treating macOS-style unlock behavior as universal.
+- Provider responses reflecting sensitive-looking content.
+  Provider output is untrusted and safe-path behavior must continue to redact or drop raw secret-like content from user-visible error paths.
+
+## V1 Security Invariants
+
+- The preferred safe path never requires the LLM, caller, or child process to see the raw secret value.
+- Compatibility-path commands are explicit and secondary. `get`, `env`, and `run` remain available for existing workflows, but new integrations should prefer `broker`.
+- Secret identity and env binding are distinct concepts. `SecretRef` is the primary opaque identifier; descriptors such as `env/OPENAI_API_KEY` are logical bindings.
+- If a brokered operation has policy, policy is evaluated before secret resolution or provider execution. Missing or non-matching policy fails closed.
+- Raw secret values must not be emitted in stdout, stderr, or structured audit events on the safe path.
+- Safe-path output should return only the minimum result metadata needed by the caller.
+- V1 audit may retain opaque secret refs, backend identifiers, target resources, and process metadata. Raw secret values and direct env-style secret names are out of bounds.
+- Headless and interactive environments have different trust assumptions and must be documented separately in backend/provider work.
+
+## Explicit Non-goals For V1
+
+- full enterprise IAM, OBO, or workload identity integration
+- multiple brokered providers at once
+- full cross-platform backend parity in the first broker MVP
+- a generalized policy DSL
+- immediate removal of compatibility-path commands
+- exhaustive metadata minimization for every audit field
+- solving every CI, remote, or distributed secret workflow in v1
+
+## Consequences For Follow-up Work
+
+- Issue `#6` should continue to frame the roadmap around the safe path, not around storage backend generalization by itself.
+- Issue `#9` must describe backend capabilities in terms of these trust boundaries, especially headless versus interactive assumptions.
+- Issue `#12` must keep README and CLI wording aligned with the safe path versus compatibility path distinction defined here.
+- Issue `#13` must preserve opaque refs, deny-before-resolution, and sanitized outputs as its proof points for the brokered MVP.

--- a/lib/kxxx/broker.sh
+++ b/lib/kxxx/broker.sh
@@ -447,9 +447,12 @@ Usage:
   kxxx broker audit [--file <path>]
 
 Notes:
+  - `broker` is the preferred safe path for new integrations.
   - This MVP only supports github.create_issue.
+  - Compatibility-path commands (`get`, `env`, `run`) can materialize raw secret values and remain explicit exceptions.
   - Policy is loaded from ~/.config/kxxx/broker/github.create_issue.repos.
   - Structured broker audit defaults to ~/.local/state/kxxx/broker.audit.jsonl.
+  - Canonical threat model: https://github.com/kxxx-dev/kxxx/blob/main/docs/adr/0001-agent-safe-secret-runtime.md
 USAGE
 }
 

--- a/test/broker.bats
+++ b/test/broker.bats
@@ -56,6 +56,26 @@ teardown() {
     kxxx_github_http_create_issue || true
 }
 
+@test "top-level help distinguishes safe path from compatibility path" {
+  run "$ROOT_DIR/bin/kxxx" --help
+
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"Modes:"* ]]
+  [[ "$output" == *"Safe path: \`kxxx broker ...\` is the preferred path for new integrations"* ]]
+  [[ "$output" == *"Compatibility path: \`kxxx get\`, \`kxxx env\`, and \`kxxx run\` can materialize raw secrets"* ]]
+  [[ "$output" == *"Threat model and invariants: https://github.com/kxxx-dev/kxxx/blob/main/docs/adr/0001-agent-safe-secret-runtime.md"* ]]
+}
+
+@test "broker help keeps MVP scope and links to the canonical invariants" {
+  run "$ROOT_DIR/bin/kxxx" broker --help
+
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"\`broker\` is the preferred safe path for new integrations."* ]]
+  [[ "$output" == *"This MVP only supports github.create_issue."* ]]
+  [[ "$output" == *"Compatibility-path commands (\`get\`, \`env\`, \`run\`) can materialize raw secret values"* ]]
+  [[ "$output" == *"Canonical threat model: https://github.com/kxxx-dev/kxxx/blob/main/docs/adr/0001-agent-safe-secret-runtime.md"* ]]
+}
+
 @test "github.create_issue emits structured audit sequence without exposing the secret" {
   local secret="github_pat_super_secret_value_123456789"
   local ref=""


### PR DESCRIPTION
## Summary
- add ADR 0001 as the canonical threat model and invariant reference for the agent-safe secret runtime
- align README, safe-path MVP docs, and CLI help around safe path vs compatibility path terminology
- add help-output regression coverage for the new wording

## Testing
- bash -n bin/kxxx lib/kxxx/*.sh test/test_helper.bash
- zsh -n completions/_kxxx
- bats test/broker.bats

Closes #7