### PR TITLE
docs: rewrite project story around safe path

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,103 +1,177 @@
 # kxxx
 
-`kxxx` is a secret runtime that now includes an experimental brokered safe path while keeping compatibility commands for existing secret-loading workflows.
+`kxxx` is a secret runtime for local developer workflows that is being repositioned around an agent-safe execution model.
 
-Safe path is preferred for new integrations, and new integrations should prefer brokered execution when possible. In the safe path, `kxxx` resolves secret material internally and returns only the brokered result. Compatibility-path commands remain available for existing workflows, but they can materialize raw secrets to the caller or child process environment and are therefore less safe.
+Today, it can still do familiar compatibility-path work such as resolving secrets, exporting env vars, and launching child processes with injected secrets. But the intended direction is different: new integrations should prefer a brokered safe path where `kxxx` remains the policy and secret-resolution boundary, and the caller receives only the minimum result metadata needed to continue.
 
-The canonical threat model and v1 security invariants live in [docs/adr/0001-agent-safe-secret-runtime.md](docs/adr/0001-agent-safe-secret-runtime.md). In short: the safe path keeps raw secret values behind the broker boundary, compatibility-path commands remain explicit legacy mode, secret identity is distinct from env bindings, and current v1 audit intentionally keeps sanitized metadata such as opaque refs, backend names, target resources, and process context. The current narrow MVP is `kxxx broker github.create_issue`, and [docs/SAFE_PATH_MVP.md](docs/SAFE_PATH_MVP.md) defines only that slice boundary and its current limitations.
+That distinction matters because a “better keychain CLI” is not the real goal. The project is moving toward a model where storage backend choice, secret identity, policy, and audit all support safer agent/tool execution by default. The threat model and invariants that define that direction live in [ADR 0001](docs/adr/0001-agent-safe-secret-runtime.md). This README is the contributor-facing overview of what exists today and what direction the project is taking.
+
+## What kxxx Solves Today
+
+- It stores and retrieves secrets for local workflows.
+- It separates logical secret descriptors such as `env/OPENAI_API_KEY` from opaque `SecretRef` identifiers.
+- It supports backend selection behind a common CLI surface.
+- It exposes one narrow brokered safe path today: `kxxx broker github.create_issue`.
+- It keeps existing compatibility flows available for users who still need env-materializing behavior.
+
+## What It Is Moving Toward
+
+The long-term direction is an agent-safe secret runtime, not just a storage abstraction layer.
+
+- The preferred safe path should avoid showing raw secret values to an LLM, agent, or other tool-using caller.
+- Secret identity should stay distinct from env var naming so policy and audit can reason about explicit references instead of implicit process state.
+- Backend/provider strategy should support both interactive desktop workflows and headless/non-interactive environments without treating macOS keychain behavior as the architecture.
+- Policy and audit should be part of the runtime boundary, not bolt-ons after storage is generalized.
+
+The current brokered GitHub issue flow is a proof point for that direction, not the finished product.
 
 ## Safe Path vs Compatibility Path
 
-- Preferred safe path: `kxxx broker github.create_issue` accepts an opaque `SecretRef`, applies a minimal repo allowlist policy, records structured broker audit events, then (if allowed) resolves the secret internally and performs the provider call without returning the raw secret.
-- Safe path audit: `kxxx broker audit` exports the structured broker event log from `~/.local/state/kxxx/broker.audit.jsonl` by default, or from `KXXX_BROKER_AUDIT_LOG` / `--file <path>` when overridden.
-- Compatibility path: `get`, `env`, and `run` remain available for existing workflows and can still materialize raw secret values to the caller or child process environment.
-- Legacy audit path: `kxxx audit` still scans files for leaked secrets; it does not read or format the broker runtime audit log.
+`kxxx` currently has two clearly different usage modes.
 
-This MVP keeps the new safe path intentionally narrow:
+### Safe Path
 
-- only `github.create_issue` is brokered
-- broker-visible refs are limited to `kxxx`-managed `secretref:v1:keychain:*` and `secretref:v1:encrypted-file:*` identities, plus process-local `secretref:v1:memory:*` refs for tests and internal APIs
-- policy is a minimal exact-match allowlist loaded from `~/.config/kxxx/broker/github.create_issue.repos`
-- structured broker audit events are stored as JSONL and never include raw secret material
+The preferred safe path is broker-oriented.
+
+- The caller passes an opaque `SecretRef` and operation arguments.
+- `kxxx` evaluates policy before resolving the secret or performing the provider action.
+- `kxxx` resolves the secret internally and returns only brokered result metadata.
+- Structured broker audit records capture the action without emitting the raw secret.
+
+Today, the narrow safe-path MVP is:
+
+```bash
+ref="$(kxxx ref env/GITHUB_TOKEN --service kxxx.secrets)"
+kxxx broker github.create_issue \
+  --service kxxx.secrets \
+  --ref "$ref" \
+  --repo octo/repo \
+  --title "hello"
+```
+
+This flow is intentionally limited to one provider operation, one policy shape, and one audit format. See [docs/SAFE_PATH_MVP.md](docs/SAFE_PATH_MVP.md) for the exact slice boundary.
+
+### Compatibility Path
+
+Compatibility-path commands remain available for existing workflows:
+
+- `kxxx get`
+- `kxxx env`
+- `kxxx run`
+
+These commands can materialize raw secret values to stdout or to a child-process environment. They remain supported because users still need them, but they are not the preferred direction for new integrations.
+
+Example compatibility flow:
+
+```bash
+kxxx run --repo auto -- npm run dev
+```
+
+## Backend And Provider Model
+
+`kxxx` now routes persistent storage through a backend layer instead of calling macOS keychain helpers directly from business logic.
+
+Current backend state:
+
+- `auto` is the default selection.
+- `darwin-keychain` preserves the current `security` / `ks` behavior on supported macOS environments.
+- `encrypted-file` is the current headless-safe persistent backend and requires `KXXX_ENCRYPTED_FILE_KEY`.
+- `memory` exists for tests and internal same-process scenarios only; it is not intended as a normal CLI backend.
+- `secret-service` and `wincred` are named backend targets but are not implemented yet.
+
+Important caveat:
+
+- `auto` is platform-based today, not fully headless-aware. On headless or non-interactive macOS environments, prefer `--backend encrypted-file` or `KXXX_BACKEND=encrypted-file` explicitly.
+
+The safe path also has a provider side, but that layer is intentionally narrow right now. The only brokered provider operation currently exposed is `github.create_issue`.
+
+## Secret Identity Is Not Env Binding
+
+One of the core architectural changes in `kxxx` is that secret identity is no longer tied to env var names.
+
+- A descriptor such as `env/OPENAI_API_KEY` or `app/my-repo/API_TOKEN` is a logical binding used for compatibility and migration.
+- A `SecretRef` such as `secretref:v1:encrypted-file:...` is the opaque identity used by the safe path.
+- This split allows policy, audit, and backend choice to reason about secrets without making env var naming the primary storage model.
+
+That distinction is already visible in the CLI:
+
+```bash
+kxxx set env/OPENAI_API_KEY --stdin < ~/.secrets/openai
+kxxx ref env/OPENAI_API_KEY --service kxxx.secrets
+```
 
 ## Threat Model Summary
 
-- The preferred safe path never requires the caller or an LLM/agent to see the raw secret value; the caller supplies only a `SecretRef` plus operation arguments.
-- Compatibility-path commands remain explicit and secondary. `get`, `env`, and `run` can still materialize raw secrets for existing workflows.
-- When a brokered operation has policy, policy is evaluated before secret resolution or provider execution.
-- Raw secret values must not be emitted to stdout, stderr, or structured broker audit events.
-- The current v1 audit trail may still retain opaque refs, backend identifiers, target resources, and process metadata. Further metadata minimization is deferred until after the MVP.
-- Interactive desktop keyrings and headless/CI execution are different trust environments and should not be treated as interchangeable backend assumptions. The current implementation does not claim broader headless-safe backend support.
+The full threat model lives in [ADR 0001](docs/adr/0001-agent-safe-secret-runtime.md). The short version is:
 
-## Backend Strategy
+- The preferred safe path should not require the caller, LLM, or child process to see the raw secret value.
+- Compatibility-path commands are explicit exceptions and remain secondary.
+- If a brokered operation has policy, policy is evaluated before secret resolution or provider execution.
+- Raw secret values must not appear in stdout, stderr, or structured safe-path audit events.
+- Audit may still contain sanitized metadata such as opaque refs, backend identifiers, target resources, and process context.
+- Interactive desktop keyrings and headless/non-interactive environments have different trust assumptions and should not be conflated.
 
-- `auto` is the default backend selection. Today it is platform-based: it resolves to `darwin-keychain` on supported macOS environments and to `encrypted-file` everywhere else.
-- `darwin-keychain` preserves the current `security` / `ks` behavior behind the new backend layer.
-- `encrypted-file` is the headless-safe persistent backend. It requires `KXXX_ENCRYPTED_FILE_KEY` and optionally accepts `KXXX_ENCRYPTED_FILE_PATH`.
-- On headless or non-interactive macOS environments, prefer `--backend encrypted-file` or `KXXX_BACKEND=encrypted-file` explicitly instead of relying on `auto`.
-- `memory` remains internal/test-only and is not intended as a normal CLI backend.
-- `secret-service` and `wincred` are named backend targets, but they currently fail explicitly until real platform adapters exist.
+## Migration Notes For Existing Users
 
-## Install (Homebrew tap)
+Existing users do not need to abandon current workflows all at once.
 
-```bash
-brew tap kxxx-dev/kxxx
-brew install kxxx
-```
+- If you already use `get`, `env`, or `run`, those commands still exist and remain the compatibility path.
+- If you previously thought in terms of env-style secret names only, start by using `kxxx ref` to discover the corresponding opaque `SecretRef`.
+- If you need a persistent backend in CI or other headless environments, prefer `encrypted-file` and supply `KXXX_ENCRYPTED_FILE_KEY`.
+- If you are moving from older keychain service names, continue using `migrate service` and `migrate import` to consolidate into the current layout.
 
-## Commands
+Example headless-safe persistent setup:
 
 ```bash
-kxxx set <account> [--value <value>|--stdin] [--json] [--service <name>] [--backend <name>]
-kxxx ref <account> [--service <name>] [--backend <name>] [--json]
-kxxx get <account> [--service <name>] [--backend <name>] [--fallback-service <name>]
-kxxx list [--service <name>] [--backend <name>] [--json]
-kxxx env [--repo <auto|name>] [--shell <zsh|bash|dotenv|json>] [--service <name>] [--backend <name>] [--strict]
-kxxx run [--repo <auto|name>] [--service <name>] [--backend <name>] -- <command...>
-kxxx broker github.create_issue [--service <name>] --ref <secret-ref> --repo <owner/repo> --title <title> [--body <body>]
-kxxx broker audit [--file <path>]
-kxxx migrate import [--dry-run|--apply] [--service <name>] [--backend <name>] [--keys-root <path>]
-kxxx migrate service [--from nil.secrets] [--to kxxx.secrets] [--from-backend <name>] [--to-backend <name>] [--dry-run|--apply]
-kxxx audit [--summary|--list] [--strict] [paths...]
+export KXXX_ENCRYPTED_FILE_KEY="replace-me"
+kxxx set env/GITHUB_TOKEN --service kxxx.secrets --backend encrypted-file --stdin < ~/.secrets/github-token
 ```
 
-LLM-friendly output:
-```bash
-kxxx list --service kxxx.secrets --json
-kxxx set env/OPENAI_API_KEY --value secret-value --json
-```
+## CLI Surface
 
-## Defaults
+The CLI now has three main groups:
+
+- secret management and compatibility flows: `set`, `ref`, `get`, `list`, `env`, `run`
+- brokered safe-path flows: `broker github.create_issue`, `broker audit`
+- migration and scanning flows: `migrate import`, `migrate service`, `audit`
+
+Defaults:
 
 - service: `kxxx.secrets`
 - backend: `auto`
 - repo detection: `git rev-parse --show-toplevel` basename, fallback to current directory basename
 - audit roots (auto): `~/src`, `~/.config`
 
-## Typical usage
+For the exact command syntax, use `kxxx --help`.
+
+## Roadmap And Open Questions
+
+`kxxx` is still early in the transition from “developer secrets CLI” to “agent-safe secret runtime.”
+
+What exists now:
+
+- threat model and invariants
+- opaque secret references
+- backend abstraction with a headless-safe persistent option
+- one brokered provider operation with policy and audit
+
+What remains open:
+
+- broader provider coverage beyond `github.create_issue`
+- richer policy models beyond the current exact repo allowlist
+- real platform implementations for `secret-service` and `wincred`
+- clearer headless strategy on macOS when `auto` selection is not sufficient
+- how far compatibility-path flows should continue to evolve versus stabilize
+
+## Supporting Docs
+
+- [ADR 0001: Agent-safe secret runtime](docs/adr/0001-agent-safe-secret-runtime.md)
+- [Safe Path MVP Brief](docs/SAFE_PATH_MVP.md)
+- [Migration from dotfiles keychain scripts](docs/MIGRATION_FROM_DOTFILES.md)
+
+## Install
 
 ```bash
-# preferred safe path today: look up an opaque ref and pass only that ref to the broker
-ref="$(kxxx ref env/GITHUB_TOKEN --service kxxx.secrets)"
-kxxx broker github.create_issue --service kxxx.secrets --ref "$ref" --repo octo/repo --title "hello"
-
-# current MVP note: process-local memory refs are still mainly for tests and internal APIs
-# see docs/SAFE_PATH_MVP.md for the current slice boundary and limitations
-
-# set global env secret
-kxxx set env/OPENAI_API_KEY --stdin < ~/.secrets/openai
-
-# headless-safe persistent backend example
-export KXXX_ENCRYPTED_FILE_KEY="replace-me"
-kxxx set env/GITHUB_TOKEN --service kxxx.secrets --backend encrypted-file --stdin < ~/.secrets/github-token
-
-# compatibility path: run app command with injected vars
-kxxx run --repo auto -- npm run dev
-
-# compatibility path: print export lines for current shell
-eval "$(kxxx env --repo auto --shell zsh)"
-
-# one-time service migration for existing users
-kxxx migrate service --from nil.secrets --to kxxx.secrets --dry-run
-kxxx migrate service --from nil.secrets --to kxxx.secrets --apply
+brew tap kxxx-dev/kxxx
+brew install kxxx
 ```

--- a/docs/SAFE_PATH_MVP.md
+++ b/docs/SAFE_PATH_MVP.md
@@ -2,7 +2,7 @@
 
 This slice adds the first brokered safe path to `kxxx` without changing the legacy compatibility commands.
 
-The canonical threat model and v1 security invariants live in [ADR 0001: Agent-safe secret runtime](adr/0001-agent-safe-secret-runtime.md). This brief is intentionally narrower: it describes the current MVP boundary and should not be treated as the source of truth for broader security policy or long-term non-goals.
+The canonical threat model and v1 security invariants live in [ADR 0001: Agent-safe secret runtime](adr/0001-agent-safe-secret-runtime.md). The broader contributor-facing product story lives in the repository [README](../README.md). This brief is intentionally narrower: it describes only the current MVP boundary and should not be treated as the source of truth for broader product positioning, security policy, or long-term non-goals.
 
 ## What It Adds
 
@@ -19,8 +19,7 @@ The caller provides only a `SecretRef` plus the brokered operation arguments.
 `kxxx` checks policy at the broker boundary, resolves the raw secret internally, and performs the provider call behind that boundary.
 The broker result and structured audit events never include the raw secret.
 
-This MVP implements the ADR invariants that the safe path keeps raw secret material behind the broker boundary, treats compatibility-path commands as explicit exceptions, and evaluates policy before secret resolution when policy exists.
-Compatibility-path commands still exist, but they are not part of this safe-path boundary.
+This MVP implements the ADR invariants that the safe path keeps raw secret material behind the broker boundary, treats compatibility-path commands as explicit exceptions, and evaluates policy before secret resolution when policy exists. Compatibility-path commands still exist, but they are not part of this safe-path boundary.
 
 `kxxx broker audit` exports the broker runtime JSONL log from `~/.local/state/kxxx/broker.audit.jsonl` by default.
 If `KXXX_BROKER_AUDIT_LOG` or `--file <path>` is provided, that path is used instead.


### PR DESCRIPTION
## Summary
- rewrite the README around the safe-path vs compatibility-path story instead of a feature dump
- make README the primary contributor-facing overview for current capability, direction, migration, and roadmap
- keep SAFE_PATH_MVP as a narrow implementation brief rather than a second project overview

## Testing
- manual doc review for terminology, examples, and link alignment

Closes #12