### PR TITLE
chore: pin GitHub Actions to commit SHA

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -23,7 +23,7 @@ jobs:
 
     steps:
       - name: Check out repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
       - name: Install test dependencies
         run: |


### PR DESCRIPTION
## Summary
- `actions/checkout@v6`（存在しないタグ）を `actions/checkout@v4` の SHA ピン留めに修正
- セキュリティ監査で検出された CI 不具合 + supply-chain attack リスクへの対応

## Test plan
- [ ] CI が正常に実行されることを確認