### PR TITLE
chore: remove LITELLM_MASTER_KEY from migration

### DIFF
--- a/lib/kxxx/migrate.sh
+++ b/lib/kxxx/migrate.sh
@@ -2,7 +2,6 @@
 
 kxxx_migrate_required_accounts=(
   "env/ZAI_API_KEY"
-  "env/LITELLM_MASTER_KEY"
   "env/GITHUB_MCP_TOKEN"
   "aws/maple-ogino/password"
   "aws/maple-ogino/console_login_link"
@@ -47,7 +46,7 @@ kxxx_migrate_collect_import_accounts() {
       value="${value#\'}"
 
       case "$name" in
-        ZAI_API_KEY|LITELLM_MASTER_KEY|GITHUB_MCP_TOKEN)
+        ZAI_API_KEY|GITHUB_MCP_TOKEN)
           accounts_ref+=("env/${name}")
           values_ref+=("$value")
           ;;


### PR DESCRIPTION
## Summary
- litellm 廃止に伴い `migrate.sh` から `LITELLM_MASTER_KEY` を削除
- `kxxx_migrate_required_accounts` 配列と secrets インポートの case 文から除去

## Test plan
- [ ] `kxxx migrate import --dry-run` が正常に動作すること
- [ ] `LITELLM_MASTER_KEY` が required accounts に含まれないこと